### PR TITLE
Add separate status column with color-coded badges

### DIFF
--- a/app/views/boletos/_bank_billet.html.erb
+++ b/app/views/boletos/_bank_billet.html.erb
@@ -15,6 +15,20 @@
   <td class="is-hidden-touch"><%= boleto.customer_city_name %></td>
   <td class="has-text-centered is-hidden-touch"><%= boleto.customer_state %></td>
   <td id=<%= "status_#{boleto.id}" %>>
+    <% case boleto.status %>
+    <% when "opened", "generating" %>
+      <span class="tag is-success"><%= t(".status.#{boleto.status}") %></span>
+    <% when "canceled" %>
+      <span class="tag is-danger"><%= t(".status.#{boleto.status}") %></span>
+    <% when "paid" %>
+      <span class="tag is-info"><%= t(".status.#{boleto.status}") %></span>
+    <% when "overdue" %>
+      <span class="tag is-warning"><%= t(".status.#{boleto.status}") %></span>
+    <% else %>
+      <span class="tag"><%= boleto.status.capitalize %></span>
+    <% end %>
+  </td>
+  <td>
     <% if ["opened", "generating"].include? boleto.status %>
       <%= link_to t('.cancel'),
                   cancel_boleto_path(boleto.id),
@@ -25,8 +39,6 @@
                     turbo_frame: "boleto_frame"
                   }
       %>
-    <% else %>
-      <%= boleto.status.capitalize %>
     <% end %>
   </td>
 </tr>

--- a/app/views/boletos/index.html.erb
+++ b/app/views/boletos/index.html.erb
@@ -29,6 +29,7 @@
       <th class="is-hidden-touch"><%= t('boletos.form.customer_city_name') %></th>
       <th class="is-hidden-touch"><%= t('boletos.form.customer_state') %></th>
       <th><%= t('boletos.form.status') %></th>
+      <th><%= t('.actions') %></th>
     </tr>
   </thead>
   <tbody id="boletos">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
       back: Back
     index:
       create_bank_billet: Create bank billet
+      actions: Actions
     show:
       edit_bank_billet: Edit bank billet
       cancel_bank_billet: Cancel bank billet
@@ -41,3 +42,9 @@ en:
       show_bank_billet: Show bank billet
     bank_billet:
       cancel: Cancel
+      status:
+        opened: Open
+        generating: Generating
+        canceled: Canceled
+        paid: Paid
+        overdue: Overdue

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -32,6 +32,7 @@ pt:
       back: Voltar
     index:
       create_bank_billet: Criar boleto
+      actions: Ações
     show:
       edit_bank_billet: Alterar boleto
       cancel_bank_billet: Cancelar boleto
@@ -41,4 +42,10 @@ pt:
       show_bank_billet: Mostrar boleto
     bank_billet:
       cancel: Cancelar
+      status:
+        opened: Aberto
+        generating: Gerando
+        canceled: Cancelado
+        paid: Pago
+        overdue: Vencido
   


### PR DESCRIPTION
- Split status display and actions into separate table columns
- Add color-coded status badges using Bulma tags:
  - Green for Open/Generating
  - Red for Canceled
  - Blue for Paid
  - Yellow for Overdue
- Add translations for status labels in English and Portuguese
- Add "Actions" column header for cancel button
- Improve visual clarity of billet status at a glance

🤖 Generated with [Claude Code](https://claude.ai/code)